### PR TITLE
When ProjectUniqueNameNew has relative path like this : "../directory…

### DIFF
--- a/src/RenameProjectVsExtension/Core/ProjectRenamer.cs
+++ b/src/RenameProjectVsExtension/Core/ProjectRenamer.cs
@@ -26,7 +26,7 @@ namespace Core
         public IEnumerable<string> SolutionProjects { get; set; }
 
         internal string ProjectUniqueNameNew => ProjectUniqueName.Replace(ProjectName, ProjectNameNew);
-        internal string ProjectFullNameNew => ProjectFullName.Replace(ProjectUniqueName, ProjectUniqueNameNew);
+        internal string ProjectFullNameNew => ProjectFullName.Replace(ProjectName, ProjectNameNew);
 
         public void FullRename()
         {


### PR DESCRIPTION
…Name/FileName" -> ProjectFullNameNew will not be replaced with a new ProjectName.