### PR TITLE
Added logic to rename properly in renamed project itself

### DIFF
--- a/src/RenameProjectVsExtension/Core/ProjectRenamer.cs
+++ b/src/RenameProjectVsExtension/Core/ProjectRenamer.cs
@@ -153,6 +153,11 @@ namespace Core
                         projFileText,
                         $"namespace{spaces}{ProjectName}",
                         $"namespace {ProjectNameNew}");
+                    projFileText = Regex.Replace(
+                        projFileText,
+                        $"using{spaces}{ProjectName}",
+                        $"using {ProjectNameNew}");
+                    projFileText = projFileText.Replace($"{ProjectName}.", $"{ProjectNameNew}.");
                     FileManager.WriteAllText(filePathWithRenamedFolder, projFileText);
                 }
 


### PR DESCRIPTION
Corrected files in the renamed project with references to the project itself via using statements and ProjectName. occurrences. This occurs when we are referencing files from other folders in the renamed project.